### PR TITLE
Enforce email required

### DIFF
--- a/longerusernameandemail/models.py
+++ b/longerusernameandemail/models.py
@@ -30,6 +30,7 @@ def patch_user_model_username(model):
 def patch_user_model_email(model):
     field = model._meta.get_field("email")
 
+    field.blank = False
     field.max_length = MAX_USERNAME_LENGTH()
     field.help_text = _("Required, %s characters or fewer. Only letters, "
                         "numbers, and @, ., +, -, or _ "


### PR DESCRIPTION
Hi, based on the help_text and the unique=True changes on the email column it seems the intention is to make the email column required. This change enforces that at the model layer.

Cheers!
