### PR TITLE
Fix https://github.com/skoczen/django-longer-username/issues/15

### DIFF
--- a/longerusernameandemail/models.py
+++ b/longerusernameandemail/models.py
@@ -1,6 +1,6 @@
 from django.core.validators import MaxLengthValidator
 from django.db.models.signals import class_prepared
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from longerusernameandemail import MAX_USERNAME_LENGTH, REQUIRE_UNIQUE_EMAIL
 
 


### PR DESCRIPTION
This simple change fixes the linked bug in the pre-fork repo. I ran into this when trying to run celery on a project using django-longer-username-and-email